### PR TITLE
Fix TestQuery

### DIFF
--- a/rrdserver_test.go
+++ b/rrdserver_test.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 )
@@ -152,15 +153,16 @@ func TestQuery(t *testing.T) {
 	}
 
 	decoder := json.NewDecoder(r.Body)
-	var queryRequest QueryRequest
-	err = decoder.Decode(&queryRequest)
+	var qrs = []QueryResponse{}
+	err = decoder.Decode(&qrs)
 	if err != nil {
-		fmt.Println("error in query 1")
-		fmt.Println(err)
+		fmt.Fprintf(os.Stderr, "error in query 1: %v", err)
 	}
 
-	if len(queryRequest.Targets) < 1 {
-		t.Fatalf("Response is empty.")
+	for _, v := range qrs {
+		if len(v.Target) < 0 {
+			t.Errorf("Response is empty.")
+		}
 	}
 }
 


### PR DESCRIPTION
The struct to decode a response from the http server should be `[]QueryResponse{}`, not `QueryRequest`. That's why it wasn't decoded properly. This PR is to fix it, and also test if the length of `QueryResponse.Target` isn't `0`.

Here's the result of the test:

```
$ go test .
ok      github.com/doublemarket/grafana-rrd-server      0.023s
```