### PR TITLE
Fix a bug when parsing metrics

### DIFF
--- a/rrdserver.go
+++ b/rrdserver.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -128,7 +129,8 @@ func query(w http.ResponseWriter, r *http.Request) {
 	for _, target := range queryRequest.Targets {
 		var points [][]float64
 		ds := target.Target[strings.LastIndex(target.Target, ":")+1 : len(target.Target)]
-		fPath := strings.Replace(target.Target, ":"+ds, "", 1)
+		rrdDsRep := regexp.MustCompile(`:` + ds + `$`)
+		fPath := rrdDsRep.ReplaceAllString(target.Target, "")
 		fPath = config.Server.RrdPath + strings.Replace(fPath, ":", "/", -1) + ".rrd"
 		if _, err := os.Stat(fPath); err != nil {
 			fmt.Println("File", fPath, "does not exist")


### PR DESCRIPTION
This fixes a bug that the query method doesn't respond correctly to a request when a metrics name (= colon-separated file paths) contains a directory name same as a DS name.