### PR TITLE
made listen interface address configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ This server supports all endpoints (urls) defined in the [Grafana Simple JSON Da
 
    - `-h` : Shows help messages.
    - `-p` : Specifies server port. (default: 9000)
+   - `-i` : Specifies server listen address. (default: any)
    - `-r` : Specifies a directory path keeping RRD files. (default: "./sample/")
      - The server recursively searches RRD files under the directory and returns a list of them for the `/search` endpoint.
    - `-s` : Default graph step in second. (default: 10)

--- a/glide.lock
+++ b/glide.lock
@@ -1,8 +1,12 @@
 hash: 43017bc74b202d332d1654c8eddd004aeaff12e9dd381ef8fd50aa11b5d8a70b
-updated: 2017-01-18T16:48:50.170691918+09:00
+updated: 2017-07-15T15:07:37.366934589+02:00
 imports:
 - name: github.com/BurntSushi/toml
   version: bbd5bb678321a0d6e58f1099321dfa73391c1b6f
+- name: github.com/mattn/go-zglob
+  version: 95345c4e1c0ebc9d16a3284177f09360f4d20fab
+  subpackages:
+  - fastwalk
 - name: github.com/ziutek/rrd
   version: 9b5311f435c8f7e62f71ffe15b4566e6cf840738
 testImports: []

--- a/rrdserver.go
+++ b/rrdserver.go
@@ -213,7 +213,7 @@ func main() {
 	http.HandleFunc("/annotations", annotations)
 	http.HandleFunc("/", hello)
 
-	err := http.ListenAndServe(":"+strconv.Itoa(config.Server.Port), nil)
+	err := http.ListenAndServe(config.Server.IpAddr+":"+strconv.Itoa(config.Server.Port), nil)
 	if err != nil {
 		fmt.Println("ERROR:", err)
 		os.Exit(1)

--- a/rrdserver.go
+++ b/rrdserver.go
@@ -58,6 +58,7 @@ type ServerConfig struct {
 	RrdPath string
 	Step    int
 	Port    int
+	IpAddr  string
 }
 
 type ErrorResponse struct {
@@ -200,6 +201,7 @@ func SetArgs() {
 	flag.IntVar(&config.Server.Port, "p", 9000, "Server port.")
 	flag.StringVar(&config.Server.RrdPath, "r", "./sample/", "Path for a directory that keeps RRD files.")
 	flag.IntVar(&config.Server.Step, "s", 10, "Step in second.")
+	flag.StringVar(&config.Server.IpAddr, "i", "", "Network interface IP address to listen on. (default: any)")
 	flag.Parse()
 }
 
@@ -211,5 +213,8 @@ func main() {
 	http.HandleFunc("/annotations", annotations)
 	http.HandleFunc("/", hello)
 
-	http.ListenAndServe(":"+strconv.Itoa(config.Server.Port), nil)
+	err := http.ListenAndServe(":"+strconv.Itoa(config.Server.Port), nil)
+	if err != nil {
+		fmt.Println("ERROR:", err)
+	}
 }

--- a/rrdserver.go
+++ b/rrdserver.go
@@ -216,5 +216,6 @@ func main() {
 	err := http.ListenAndServe(":"+strconv.Itoa(config.Server.Port), nil)
 	if err != nil {
 		fmt.Println("ERROR:", err)
+		os.Exit(1)
 	}
 }


### PR DESCRIPTION
just in case somebody does not want grafana-rrd-server to listen on every conceivable interface;

I personally prefer making it listen on localhost only and using the proxy functionality in the datasource settings of Grafana. :)
