### PR TITLE
Allow RrdPaths without trailing slash

### DIFF
--- a/rrdserver.go
+++ b/rrdserver.go
@@ -171,7 +171,7 @@ func query(w http.ResponseWriter, r *http.Request) {
 		ds := target.Target[strings.LastIndex(target.Target, ":")+1 : len(target.Target)]
 		rrdDsRep := regexp.MustCompile(`:` + ds + `$`)
 		fileSearchPath := rrdDsRep.ReplaceAllString(target.Target, "")
-		fileSearchPath = config.Server.RrdPath + strings.Replace(fileSearchPath, ":", "/", -1) + ".rrd"
+		fileSearchPath = strings.TrimRight(config.Server.RrdPath, "/") + "/" + strings.Replace(fileSearchPath, ":", "/", -1) + ".rrd"
 
 		fileNameArray, _ := zglob.Glob(fileSearchPath)
 		for _, filePath := range fileNameArray {


### PR DESCRIPTION
So far a path without trailing slash failed silently.

For example:

```
$ ll /tmp/pnp4nagios
total 0
drwxr-xr-x 1 nagios www-data 334 feb  4 19:23 perfdata
```

```
$ grafana-rrd-server -r /tmp/pnp4nagios
```
Did fail silenty, returning null data to Grafana.

Problem is that line 174 produced the following assignation to ```fileSearchPath```
```
/tmp/pnp4nagiosperfdata/Myhost/Current_Load.rrd
```

This patch just removes the trailing slash if it exists, and adds a new trailing slash. This work for when there is and when there is not trailing slash.