### PR TITLE
Return empty array when there is no data

### DIFF
--- a/rrdserver.go
+++ b/rrdserver.go
@@ -214,7 +214,7 @@ func query(w http.ResponseWriter, r *http.Request) {
 
 		fileNameArray, _ := zglob.Glob(fileSearchPath)
 		for _, filePath := range fileNameArray {
-			var points [][]float64
+			points := make([][]float64, 0)
 			if _, err = os.Stat(filePath); err != nil {
 				fmt.Println("File", filePath, "does not exist")
 				continue


### PR DESCRIPTION
Grafana v7.1.5 (9893b8c53d) produces an error when the `datapoints` field is null. It expects an empty array.