### PR TITLE
move search cache to be updated async

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM golang:1.16-alpine AS builder
+
+RUN apk update && apk add pkgconfig rrdtool-dev gcc libc-dev
+
+WORKDIR /build
+COPY . .
+RUN go build -o grafana-rrd-server
+
+FROM alpine
+RUN apk add rrdtool rrdtool-dev
+COPY --from=builder /build/grafana-rrd-server /grafana-rrd-server
+ENTRYPOINT [ "/grafana-rrd-server" ]

--- a/README.md
+++ b/README.md
@@ -76,11 +76,37 @@ This server supports all endpoints (urls) defined in the [Grafana Simple JSON Da
        step = 300
        ```
 
-4. Setup Grafana and Simple JSON Datastore plugin.
+4. Optionally set up systemd unit:
+
+```
+useradd grafanarrd
+cat > /etc/systemd/system/grafana-rrd-server.service <<EOF
+[Unit]
+Description=Grafana RRD Server
+After=network.service
+
+[Service]
+User=grafanarrd
+Group=grafanarrd
+Restart=on-failure
+Environment="LD_LIBRARY_PATH=/opt/rrdtool-1.6/lib"
+ExecStart=/opt/grafana-rrd-server/grafana-rrd-server -p 9000 -r /path/to/rrds -s 300
+RestartSec=10s
+
+[Install]
+WantedBy=default.target
+EOF
+
+systemctl daemon-reload
+systemctl enable grafana-rrd-server
+systemctl start grafana-rrd-server
+```
+
+5. Setup Grafana and Simple JSON Datastore plugin.
 
    See [Grafana documentation](http://docs.grafana.org/)
 
-5. Create datasource.
+6. Create datasource.
 
 # Contributing
 

--- a/rrdserver_test.go
+++ b/rrdserver_test.go
@@ -34,6 +34,7 @@ func TestHello(t *testing.T) {
 
 func TestSearch(t *testing.T) {
 	SetArgs()
+	searchCache.Update()
 
 	requestJSON := `{"target":"sample"}`
 	reader := strings.NewReader(requestJSON)


### PR DESCRIPTION
Moves the search cache to be updated async. This is to allow this plugin to work with a collection of thousands of RRDs where synchronous calls to `/search` is infeasible