### PR TITLE
Update rrdserver.go

### DIFF
--- a/rrdserver.go
+++ b/rrdserver.go
@@ -341,6 +341,7 @@ func main() {
 	SetArgs()
 
 	http.HandleFunc("/search", search)
+	http.HandleFunc("/metrics", search)
 	http.HandleFunc("/query", query)
 	http.HandleFunc("/annotations", annotations)
 	http.HandleFunc("/", hello)


### PR DESCRIPTION
added support (listing rrds) for simpod-json-datasource as grafana-simple-json-datasource plugin becoming deprecated