### PR TITLE
Fix /search endpoint with no "target" parameter.

### DIFF
--- a/rrdserver.go
+++ b/rrdserver.go
@@ -197,11 +197,9 @@ func search(w http.ResponseWriter, r *http.Request) {
 
 	var result = []string{}
 
-	if target != "" {
-		for _, path := range searchCache.Get() {
-			if strings.Contains(path, target) {
-				result = append(result, path)
-			}
+	for _, path := range searchCache.Get() {
+		if strings.Contains(path, target) {
+			result = append(result, path)
 		}
 	}
 


### PR DESCRIPTION
Return all records from /search when "target" parameter is empty or not provided.

This matches the behaviour of v0.0.5 and is required by the SimpleJson Grafana data source.